### PR TITLE
Certificate ownership

### DIFF
--- a/manifests/ca-certificate.pp
+++ b/manifests/ca-certificate.pp
@@ -1,19 +1,23 @@
-define ssl::ca-certificate($ensure = 'present', $source = '', $content = '') {
-    File {
-        owner   => root,
-        group   => root,
-        notify  => Exec['update-ca-certificates'],
-        require => Package['ca-certificates'],
-    }
+define ssl::ca-certificate(
+  $ensure = 'present',
+  $source = '',
+  $content = ''
+) {
+  File {
+    owner   => 'root',
+    group   => 'root',
+    notify  => Exec['update-ca-certificates'],
+    require => Package['ca-certificates'],
+  }
 
-    if ($content) {
-        file { "/usr/local/share/ca-certificates/${name}":
-            content => $content,
-        }
+  if ($content) {
+    file { "/usr/local/share/ca-certificates/${name}":
+      content => $content,
     }
-    else {
-        file { "/usr/local/share/ca-certificates/${name}":
-            source => $source,
-        }
+  }
+  else {
+    file { "/usr/local/share/ca-certificates/${name}":
+      source => $source,
     }
+  }
 }

--- a/manifests/certificate.pp
+++ b/manifests/certificate.pp
@@ -2,7 +2,9 @@ define ssl::certificate(
   $source,
   $ensure = 'present',
   $private_key = 'private_key.key',
-  $all_in_one = ''
+  $all_in_one = '',
+  $owner = 'root',
+  $group = 'root',
 ) {
 
   file { "/etc/ssl/${name}/":
@@ -14,16 +16,16 @@ define ssl::certificate(
     recurse => true,
     purge   => true,
     force   => true,
-    owner   => 'root',
-    group   => 'root',
+    owner   => $owner,
+    group   => $group,
     mode    => '0644',
   }
 
   file { "/etc/ssl/${name}/${private_key}":
     ensure => $ensure,
     source => "${source}/${private_key}",
-    owner  => 'root',
-    group  => 'root',
+    owner  => $owner,
+    group  => $group,
     mode   => '0640',
   }
 
@@ -31,8 +33,8 @@ define ssl::certificate(
     file { "/etc/ssl/${name}/${all_in_one}":
       ensure => $ensure,
       source => "${source}/${all_in_one}",
-      owner  => 'root',
-      group  => 'root',
+      owner  => $owner,
+      group  => $group,
       mode   => '0640',
     }
   }

--- a/manifests/certificate.pp
+++ b/manifests/certificate.pp
@@ -1,38 +1,39 @@
 define ssl::certificate(
-    $ensure = 'present',
-    $source,
-    $private_key = 'private_key.key',
-    $all_in_one = '') {
+  $source,
+  $ensure = 'present',
+  $private_key = 'private_key.key',
+  $all_in_one = ''
+) {
 
-    file { "/etc/ssl/${name}/":
-        ensure  => $ensure ? {
-            present => 'directory',
-            default => $ensure,
-        },
-        source  => $source,
-        recurse => true,
-        purge   => true,
-        force   => true,
-        owner   => root,
-        group   => root,
-        mode    => 0644,
+  file { "/etc/ssl/${name}/":
+    ensure  => $ensure ? {
+      present => 'directory',
+      default => $ensure,
+    },
+    source  => $source,
+    recurse => true,
+    purge   => true,
+    force   => true,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+  }
+
+  file { "/etc/ssl/${name}/${private_key}":
+    ensure => $ensure,
+    source => "${source}/${private_key}",
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0640',
+  }
+
+  if ($all_in_one) {
+    file { "/etc/ssl/${name}/${all_in_one}":
+      ensure => $ensure,
+      source => "${source}/${all_in_one}",
+      owner  => 'root',
+      group  => 'root',
+      mode   => '0640',
     }
-    
-    file { "/etc/ssl/${name}/${private_key}":
-        ensure => $ensure,
-        source => "${source}/${private_key}",
-        owner  => root,
-        group  => root,
-        mode   => 0640,
-    }
-    
-    if ($all_in_one) {
-        file { "/etc/ssl/${name}/${all_in_one}":
-            ensure => $ensure,
-            source => "${source}/${all_in_one}",
-            owner  => root,
-            group  => root,
-            mode   => 0640,
-        }
-    }
+  }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,13 +1,13 @@
 class ssl {
-    package { ['ca-certificates', 'ssl-cert']:
-        ensure => present,
-    }
-    
-    file { '/etc/ssl':
-        ensure => directory,
-    }
-    
-    exec { 'update-ca-certificates':
-        refreshonly => true,
-    }
+  package { ['ca-certificates', 'ssl-cert']:
+    ensure => present,
+  }
+
+  file { '/etc/ssl':
+    ensure => directory,
+  }
+
+  exec { 'update-ca-certificates':
+    refreshonly => true,
+  }
 }


### PR DESCRIPTION
Add `owner` and `group` params to the `ssl::certificate` defined type.

Sometimes we have servers that read the SSL keys after the process has forked from root to the service account, so being able to set group ownership is required.
