### PR TITLE
Ensures SSL certificates can be removed if ensure => absent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+/pkg/
+/bin/
+/Gemfile.lock
+/vendor/
+spec/fixtures
+/.vagrant/
+/.bundle/
+/coverage/
+/.idea/
+*.iml
+*.swp
+.tmp

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+---
+sudo: false
+language: ruby
+cache: bundler
+bundler_args: --without system_tests
+script: "bundle exec rake lint"
+matrix:
+  fast_finish: true
+  include:
+  - rvm: 1.9.3
+    env: PUPPET_GEM_VERSION="~> 3.0"
+notifications:
+  email: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,12 @@
+source 'https://rubygems.org'
+
+gem 'rake'
+gem 'mocha'
+gem 'diff-lcs'
+gem 'json_pure'
+gem 'json'
+gem 'metadata-json-lint'
+gem 'puppet-lint', '1.1.0'
+gem 'rspec-puppet', '2.2.0'
+gem 'puppet', '>4'
+gem 'puppetlabs_spec_helper', '0.10.3'

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,10 @@
+require 'puppetlabs_spec_helper/rake_tasks'
+require 'puppet-lint/tasks/puppet-lint'
+
+PuppetLint.configuration.fail_on_warnings = true
+PuppetLint.configuration.send('relative')
+PuppetLint.configuration.send('disable_80chars')
+PuppetLint.configuration.send('disable_class_inherits_from_params_class')
+PuppetLint.configuration.send('disable_documentation')
+PuppetLint.configuration.send('disable_single_quote_string_with_variables')
+PuppetLint.configuration.ignore_paths = ["spec/**/*.pp", "pkg/**/*.pp"]

--- a/manifests/certificate.pp
+++ b/manifests/certificate.pp
@@ -1,19 +1,24 @@
 define ssl::certificate(
   $source,
-  $ensure = 'present',
+  $ensure      = 'present',
   $private_key = 'private_key.key',
-  $all_in_one = '',
-  $owner = 'root',
-  $group = 'root',
+  $all_in_one  = '',
+  $owner       = 'root',
+  $group       = 'root',
 ) {
 
   file { "/etc/ssl/${name}/":
     ensure  => $ensure ? {
       present => 'directory',
+      absent  => 'absent',
       default => $ensure,
     },
     source  => $source,
-    recurse => true,
+    recurse => $ensure ? {
+      present => true,
+      absent  => false,
+      default => true,
+    },
     purge   => true,
     force   => true,
     owner   => $owner,
@@ -21,21 +26,23 @@ define ssl::certificate(
     mode    => '0644',
   }
 
-  file { "/etc/ssl/${name}/${private_key}":
-    ensure => $ensure,
-    source => "${source}/${private_key}",
-    owner  => $owner,
-    group  => $group,
-    mode   => '0640',
-  }
-
-  if ($all_in_one) {
-    file { "/etc/ssl/${name}/${all_in_one}":
-      ensure => $ensure,
-      source => "${source}/${all_in_one}",
+  if $ensure == 'present' {
+    file { "/etc/ssl/${name}/${private_key}":
+      ensure => 'present',
+      source => "${source}/${private_key}",
       owner  => $owner,
       group  => $group,
       mode   => '0640',
+    }
+
+    if $all_in_one {
+      file { "/etc/ssl/${name}/${all_in_one}":
+        ensure => 'present',
+        source => "${source}/${all_in_one}",
+        owner  => $owner,
+        group  => $group,
+        mode   => '0640',
+      }
     }
   }
 }


### PR DESCRIPTION
At the moment certificates are ensured to be present and if we ensure absent it causes errors when removing certificates because they don't exists once the directory is removed.
- Adds .travis.yaml file so we can have basic linting tests
- Adds Gemfile
- Adds Rakefile to launch lint tests
- Validates recursion since this only works on `ensure => directory` not when `ensure => absent`
