### PR TITLE
Add metadata for Puppet 4 support.

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,15 @@
+{
+  "name": "chrisboulton-ssl",
+  "version": "0.0.2",
+  "author": "Chris Boulton <chris@chrisboulton.com>",
+  "summary": "Install and manage SSL certificates and certificate authorities",
+  "license": "MIT",
+  "source": "https://github.com/chrisboulton/puppet-ssl",
+  "project_page": "https://github.com/chrisboulton/puppet-ssl",
+  "issues_url": "https://github.com/chrisboulton/puppet-ssl/issues",
+  "dependencies": [
+    {"name":"puppetlabs-stdlib","version_requirement":">= 1.0.0"}
+  ],
+  "data_provider": null
+}
+


### PR DESCRIPTION
I've bumped the version from 0.0.1 to 0.0.2, so this should be tagged after merge.

@chrisboulton 
